### PR TITLE
Configure-Document-UI-PopUp

### DIFF
--- a/bin/ADHDReaderRun
+++ b/bin/ADHDReaderRun
@@ -3,4 +3,4 @@
 
 # Runs the application
 
-python3 scripts/main.py
+python scripts/main.py

--- a/scripts/MainWindow.py
+++ b/scripts/MainWindow.py
@@ -9,15 +9,19 @@
 
 
 from PyQt6 import QtCore, QtGui, QtWidgets
-import ReadingScreen_MileStoneScreen as rs_ms
 import ParseFile as pf
 
-class Ui_MainWindow(object):
-    def setupUi(self, MainWindow, adhdReader):
-        MainWindow.setObjectName("MainWindow")
-        MainWindow.resize(1500, 900)
-        MainWindow.setStyleSheet("background-color: rgb(252, 255, 237);")
-        self.centralwidget = QtWidgets.QWidget(MainWindow)
+class Ui_MainWindow(QtWidgets.QMainWindow):
+    def __init__(self, adhdReader: QtWidgets.QMainWindow):
+        super().__init__()
+        self.adhdReader = adhdReader
+        self.setupUi()
+
+    def setupUi(self):
+        self.setObjectName("MainWindow")
+        self.resize(1500, 900)
+        self.setStyleSheet("background-color: rgb(252, 255, 237);")
+        self.centralwidget = QtWidgets.QWidget(self)
         self.centralwidget.setObjectName("centralwidget")
         self.gridLayout = QtWidgets.QGridLayout(self.centralwidget)
         self.gridLayout.setContentsMargins(0, 0, 0, 0)
@@ -84,7 +88,7 @@ class Ui_MainWindow(object):
         self.input_options_layout.addItem(spacerItem)
 
         # The 'Upload from computer' button
-        self.importButton = QtWidgets.QPushButton(self.frame, clicked = lambda: self.importFile(adhdReader))
+        self.importButton = QtWidgets.QPushButton(self.frame, clicked = lambda: self.importFile())
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -161,7 +165,7 @@ class Ui_MainWindow(object):
         self.submit_layout.addItem(spacerItem3)
 
         # Submit button for the copy paste text box
-        self.submitButton = QtWidgets.QPushButton(self.frame, clicked = lambda: self.collectTextFromTextBox(self.copyPasteInput.toPlainText(), adhdReader))
+        self.submitButton = QtWidgets.QPushButton(self.frame, clicked = lambda: self.collectTextFromTextBox(self.copyPasteInput.toPlainText()))
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -191,15 +195,15 @@ class Ui_MainWindow(object):
         self.vertical_layout.addLayout(self.submit_layout)
         self.gridLayout_3.addLayout(self.vertical_layout, 0, 0, 1, 1)
         self.gridLayout.addWidget(self.frame, 1, 1, 1, 1)
-        MainWindow.setCentralWidget(self.centralwidget)
-        self.statusbar = QtWidgets.QStatusBar(MainWindow)
+        self.setCentralWidget(self.centralwidget)
+        self.statusbar = QtWidgets.QStatusBar(self)
         self.statusbar.setObjectName("statusbar")
-        MainWindow.setStatusBar(self.statusbar)
-        self.setupTitleBar(adhdReader)
-        self.retranslateUi(MainWindow)
-        QtCore.QMetaObject.connectSlotsByName(MainWindow)
+        self.setStatusBar(self.statusbar)
+        self.setupTitleBar()
+        self.retranslateUi()
+        QtCore.QMetaObject.connectSlotsByName(self)
 
-    def setupTitleBar(self, adhdReader):
+    def setupTitleBar(self):
         self.titleBar = QtWidgets.QWidget(parent=self.centralwidget)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
@@ -304,16 +308,16 @@ class Ui_MainWindow(object):
         self.header.addLayout(self.gridLayout_2)
         self.gridLayout.addWidget(self.titleBar, 0, 1, 1, 1)
 
-    def retranslateUi(self, MainWindow):
+    def retranslateUi(self):
         _translate = QtCore.QCoreApplication.translate
-        MainWindow.setWindowTitle(_translate("MainWindow", "ADHD Reader"))
+        self.setWindowTitle(_translate("MainWindow", "ADHD Reader"))
         self.headerText.setText(_translate("MainWindow", "Input a reading to get started:"))
         self.importButton.setText(_translate("MainWindow", "Upload from computer"))
         self.copyPasteInput.setPlainText(_translate("MainWindow", "Paste into text box..."))
         self.submitButton.setText(_translate("MainWindow", "Submit"))
         self.Title.setText(_translate("MainWindow", "ADHD Reader"))
 
-    def collectTextFromTextBox(self, inputText, adhdReader):
+    def collectTextFromTextBox(self, inputText):
         """inputText contains all the text that was placed in the text box before submit was clicked"""
         # If user clicks submit and they haven't added any text, return
         if (len(inputText) == 0 or inputText == "Paste into text box..."):
@@ -323,9 +327,9 @@ class Ui_MainWindow(object):
         parser = pf.Partition_Text(text=inputText)              # create parser
 
         # Change to reading screen 
-        self.goToReadingScreen(adhdReader, parser)           # pass in parser object
+        self.adhdReader.goToReadingScreen(parser)        # pass in parser object
 
-    def importFile(self, adhdReader):
+    def importFile(self):
         """Open the file dialog to import a .txt or .pdf"""
         # This method returns a tuple, but the ', _' syntax allows us to just grab the first index of it which has the file path
         filepath, _ = QtWidgets.QFileDialog.getOpenFileName(
@@ -343,13 +347,6 @@ class Ui_MainWindow(object):
         parser.parse_file(filepath.split(".")[-1], filepath)    # parse file
 
         # Change to reading screen
-        self.goToReadingScreen(adhdReader, parser)
+        self.adhdReader.goToReadingScreen(parser)
 
-    def goToReadingScreen(self, adhdReader, parser):
-        """Take the document or text and head to the reading screen to display it!"""
-        ui_rs = rs_ms.Ui_ReadingScreen(adhdReader, parser)
-        ui_rs.setupUi()
-
-        adhdReader.stacked_widget.addWidget(ui_rs)
-        adhdReader.stacked_widget.setCurrentIndex(1)
 

--- a/scripts/ReadingScreen_MileStoneScreen.py
+++ b/scripts/ReadingScreen_MileStoneScreen.py
@@ -50,6 +50,14 @@ class Ui_ReadingScreen(QtWidgets.QMainWindow):
                                 "background: #FFF;\n"
                                 "padding: -10 px;")
         
+        # Manually build our grey screen overlay
+        self.overlay = QtWidgets.QFrame(self)
+        self.overlay.setStyleSheet("background-color: rgba(151, 151, 151, 210);")
+        self.overlay.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
+        self.overlay.setFrameShadow(QtWidgets.QFrame.Shadow.Plain)
+        self.overlay.setGeometry(self.adhdReader.rect())
+        self.overlay.hide()
+        
         """
         This segment of code is crucial since this is how the text box widget is added.
         We can use this to remove the text box and add the milestone widget.
@@ -193,7 +201,7 @@ class Ui_ReadingScreen(QtWidgets.QMainWindow):
         self.horizontalLayout_2.addWidget(self.rightArrow)
         self.verticalLayout_2.addLayout(self.horizontalLayout_2)
         self.setCentralWidget(self.centralwidget)
-
+        
         self.retranslateUi()
         QtCore.QMetaObject.connectSlotsByName(self)
 
@@ -242,10 +250,13 @@ class Ui_ReadingScreen(QtWidgets.QMainWindow):
         """If the pop up is visible, hide it. Otherwise show it"""
         if self.configPopUp.isVisible():
             self.configPopUp.hide()
+            self.overlay.hide()
         else:
+            self.overlay.setGeometry(self.adhdReader.rect())
+            self.overlay.show()
             self.configPopUp.show()
     
     def instantiateConfigDocPopUp(self):
-        self.configPopUp = config.Ui_MainWindow(self.adhdReader)
+        self.configPopUp = config.Ui_MainWindow(self.adhdReader, self)
         self.configPopUp.hide() 
 

--- a/scripts/ReadingScreen_MileStoneScreen.py
+++ b/scripts/ReadingScreen_MileStoneScreen.py
@@ -25,6 +25,8 @@ class Ui_ReadingScreen(QtWidgets.QMainWindow):
         # Create config doc pop up
         self.instantiateConfigDocPopUp()
 
+        self.setupUi()
+
     def setupUi(self):
         self.setObjectName("MainWindow")
         self.resize(1124, 749)

--- a/scripts/configureDocumentPopUp.py
+++ b/scripts/configureDocumentPopUp.py
@@ -10,13 +10,16 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 import MainWindow as mw
 
 class Ui_MainWindow(QtWidgets.QMainWindow):
-    def __init__(self, adhdReader: QtWidgets.QMainWindow):
+    def __init__(self, adhdReader: QtWidgets.QMainWindow, readingScreen):
         super().__init__()
+        self.readingScreen = readingScreen
         self.adhdReader = adhdReader
         self.setupUi()
 
     def showEvent(self, a0: QtGui.QShowEvent) -> None:
-        self.centerPopUp
+        #this needs to be fixed
+        #self.centerPopUp()
+        pass
     
     def setupUi(self):
         self.setObjectName("MainWindow")
@@ -114,7 +117,7 @@ class Ui_MainWindow(QtWidgets.QMainWindow):
 "}")
         self.continueButton_2.setObjectName("continueButton_2")
         self.mainLayout_2.addWidget(self.continueButton_2, 0, QtCore.Qt.AlignmentFlag.AlignHCenter)
-        self.resumeReadingButton_2 = QtWidgets.QPushButton(parent=self.popUpFrame, clicked = lambda: self.close())
+        self.resumeReadingButton_2 = QtWidgets.QPushButton(parent=self.popUpFrame, clicked = lambda: self.readingScreen.toggleConfigDocPopUp())
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -140,7 +143,7 @@ class Ui_MainWindow(QtWidgets.QMainWindow):
         self.closeButtonLayout_2.setContentsMargins(-1, 2, 2, -1)
         self.closeButtonLayout_2.setSpacing(10)
         self.closeButtonLayout_2.setObjectName("closeButtonLayout_2")
-        self.closeButton_2 = QtWidgets.QToolButton(parent=self.popUpFrame, clicked = lambda: self.close())
+        self.closeButton_2 = QtWidgets.QToolButton(parent=self.popUpFrame, clicked = lambda: self.readingScreen.toggleConfigDocPopUp())
         icon = QtGui.QIcon()
         icon.addPixmap(QtGui.QPixmap("UI/icons/icons8-close-48.png"), QtGui.QIcon.Mode.Normal, QtGui.QIcon.State.Off)
         self.closeButton_2.setIcon(icon)

--- a/scripts/configureDocumentPopUp.py
+++ b/scripts/configureDocumentPopUp.py
@@ -7,7 +7,7 @@
 
 
 from PyQt6 import QtCore, QtGui, QtWidgets
-
+import MainWindow as mw
 
 class Ui_MainWindow(QtWidgets.QMainWindow):
     def __init__(self, adhdReader: QtWidgets.QMainWindow):
@@ -94,7 +94,7 @@ class Ui_MainWindow(QtWidgets.QMainWindow):
         self.subtitle_2.setWordWrap(True)
         self.subtitle_2.setObjectName("subtitle_2")
         self.mainLayout_2.addWidget(self.subtitle_2, 0, QtCore.Qt.AlignmentFlag.AlignHCenter|QtCore.Qt.AlignmentFlag.AlignTop)
-        self.continueButton_2 = QtWidgets.QPushButton(parent=self.popUpFrame, clicked = lambda: self.centerPopUp())
+        self.continueButton_2 = QtWidgets.QPushButton(parent=self.popUpFrame, clicked = lambda: self.returnToMainMenu())
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -171,6 +171,7 @@ class Ui_MainWindow(QtWidgets.QMainWindow):
         self.closeButton_2.setText(_translate("MainWindow", "..."))
 
     def centerPopUp(self):
+        """Grab the current size of the screen to center the pop up in the middle"""
         screen = self.adhdReader.geometry()
 
         popupSize = self.geometry()
@@ -184,4 +185,8 @@ class Ui_MainWindow(QtWidgets.QMainWindow):
 
         # move the popup to the center
         self.setGeometry(center_x, center_y, widgetWidth, widgetHeight)
+        
+    def returnToMainMenu(self):
+        self.adhdReader.goToMainMenu()
+        self.close()
         

--- a/scripts/configureDocumentPopUp.py
+++ b/scripts/configureDocumentPopUp.py
@@ -18,8 +18,7 @@ class Ui_MainWindow(QtWidgets.QMainWindow):
 
     def showEvent(self, a0: QtGui.QShowEvent) -> None:
         #this needs to be fixed
-        #self.centerPopUp()
-        pass
+        self.centerPopUp()
     
     def setupUi(self):
         self.setObjectName("MainWindow")
@@ -175,16 +174,17 @@ class Ui_MainWindow(QtWidgets.QMainWindow):
 
     def centerPopUp(self):
         """Grab the current size of the screen to center the pop up in the middle"""
-        screen = self.adhdReader.geometry()
 
-        popupSize = self.geometry()
+        # get current location of screen
+        screen_center = self.adhdReader.frameGeometry().center()
 
-        # calculate central position
-        center_x = int((screen.width() - popupSize.width()) / 2)
-        center_y = int((screen.height() - popupSize.height()) / 2)
-
+        # get pop up data
         widgetWidth = self.frameGeometry().width()
         widgetHeight = self.frameGeometry().height()
+
+        # calculate central position
+        center_x = int(screen_center.x() - widgetWidth / 2)
+        center_y = int(screen_center.y() - widgetHeight / 2)
 
         # move the popup to the center
         self.setGeometry(center_x, center_y, widgetWidth, widgetHeight)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,6 +1,7 @@
 import sys
 from PyQt6 import QtWidgets
 import MainWindow as mw
+import ReadingScreen_MileStoneScreen as rs_ms
 import configureDocumentPopUp as config
 
 class ADHDReader(QtWidgets.QMainWindow):
@@ -9,13 +10,29 @@ class ADHDReader(QtWidgets.QMainWindow):
         
         self.stacked_widget = QtWidgets.QStackedWidget()
 
-        MainWindow = QtWidgets.QMainWindow()
-        ui = mw.Ui_MainWindow()
-        ui.setupUi(MainWindow, self)
+        MainWindow = mw.Ui_MainWindow(self)
 
         self.stacked_widget.addWidget(MainWindow)
         self.setCentralWidget(self.stacked_widget)
         self.resize(1500, 900)
+
+    def goToReadingScreen(self, parser):
+        """Take the document or text and head to the reading screen to display it!"""
+        ui_rs = rs_ms.Ui_ReadingScreen(self, parser)
+
+        self.stacked_widget.addWidget(ui_rs)
+        self.stacked_widget.setCurrentIndex(self.stacked_widget.indexOf(ui_rs))
+
+    def goToMainMenu(self):
+        """Clean up instantiated widgets and go back to the main menu"""
+        MainWindow = mw.Ui_MainWindow(self)
+        for index in range(self.stacked_widget.count()):
+            widget = self.stacked_widget.widget(index)
+            if widget:
+                self.stacked_widget.removeWidget(widget)
+        
+        self.stacked_widget.addWidget(MainWindow)
+        self.stacked_widget.setCurrentIndex(self.stacked_widget.indexOf(MainWindow))
         
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Trello Ticket
https://trello.com/c/VWbsSaTb/67-configure-document-to-add-a-different-doc

# Changes Made:
1. Refactored how changing between screens works for better readability and architecture
2. Configure document pop up appears when pressing config doc button on reading screen. Clicking 'Continue' brings you back to the main menu and allows you to select a new document

# Known Issues:
1. Border behind UI frame persists. I could not for the life of me figure out how to remove it.
2. After opening the pop up, if you resize the main window the grey overlay will not dynamically resize with it. This can be fixed later but for now I doubt many people will run into this bug. 

# Video

https://github.com/Bbox123/eecs495-adhd-document-reader/assets/97642146/b871365b-7699-4c50-b47a-3bddea50266e

